### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "arg_parse"
-version = "0.1.1"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arg_parse"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Oxydemeton"]
 description = "A tool to parse console or your own arguments, without dependencies."

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ The interface for developer is work in progress. So expect minor and major chang
 arg_parse is a tool to simplify the processing of command line arguments. It doesn't have any dependencies and the initialization is done at compile time.<br>
 
 # Features & Goals
-- [x] Parsing of `flags` (Values set with `--` which default is false and set to true by being used.)
-- [x] Parsing of `parameters` (Values mentioned after `-` which have their value(as a string) followed)
+- [x] Parsing of `short options` (Values set with `--` which default is false and set to true by being used.)
+- [x] Parsing of `long options` (Values mentioned after `-` which have their value(as a string) followed)
+- [ ] Parsing of `non options` (Single Values parameters without any prefix )
 - [ ] Parsing of `sub commands` (which only one can be used and all following arguments are related to)
 - [x] Returning results instead of throwing unfinished error messages
 - [ ] Simple creation of parser
@@ -15,8 +16,7 @@ arg_parse is a tool to simplify the processing of command line arguments. It doe
 - [ ] Ability to provide default values
 - [ ] Ability to make Argument or subcommand required
 - [ ] Cache the result of parsing the cli arguments to improve performance slightly
-- [ ] Easy macro or function to configure the parser
-- [ ] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
+- [x] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
 
 # Installation
 #### Only version 0.1.1 is published yet!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Disclaimer
 The interface for developer is work in progress. So expect minor and major changes when updating until v1.0<br>
 # Description
-arg_parse is a tool to simplify the processing of command line arguments. It doesn't have any dependencies and the initialization is done at compile time.
+arg_parse is a tool to simplify the processing of command line arguments. It doesn't have any dependencies and the initialization is done at compile time.<br>
 
 # Features & Goals
 - [x] Parsing of `flags` (Values set with `--` which default is false and set to true by being used.)
@@ -19,6 +19,7 @@ arg_parse is a tool to simplify the processing of command line arguments. It doe
 - [ ] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
 
 # Installation
+#### Only version 0.1.1 is published yet!
 Add `arg_parse = "0.1.1"` to your cargo dependencies (`cargo.toml`).
 ```toml
 [dependencies]
@@ -26,28 +27,45 @@ arg_parse = "0.1.1"
 ```
 
  # Example
- Prints if the flag `--a` is provided and the parameter provided under `-b`
+ Prints the Options which are found or parsing errors.<br>
+ Arguments:
+ - LongOption: `hello` without any further arguments
+ - ShortOption: `b` with two arguments
+ - ShortOption: `a` without any arguments
  ```rust
- use arg_parse::ArgParser;
- use arg_parse::config;
- // Define all Arguments of the program itself/root command (compile time)
- const ARGS: &'static [config::Arg] = &[config::Arg::Flag("a"), config::Arg::Parameter("b")];
- // Define the Root Command, without any possible sub commands (compile time)
- const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(ARGS, &[]);
- // Create the Parser in static memory, available everywhere (Created at compile time)
- static PARSER: ArgParser = ArgParser::from(PARSER_ROOT_CMD);
- 
- fn main() {
-     //Parse the by the user provided Arguments
-     let root_cmd = PARSER.parse();
-     match root_cmd {
-         Ok(result) => println!("Result: {:?}", result),
-         Err(error) => println!("ERROR: {:?}", error)
-     }
- }
+use arg_parse::ArgParser;
+use arg_parse::config;
+
+//List of all available long options
+const LONG_OPTIONS: &'static [config::LongOption] = &[
+    //Define a long option called hello without parameters
+    config::LongOption{name: "hello", value_count: 0}
+    ];
+//List of all available short options
+const SHORT_OPTIONS: &'static [config::ShortOption] = &[
+    //Define a short option called b with two parameters
+    config::ShortOption{name:'b', value_count: 2},
+    //Define a short option called a without parameters
+    config::ShortOption{name:'a', value_count: 0}
+    ];
+
+//Create the root command which is the program itself basically
+const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(SHORT_OPTIONS, LONG_OPTIONS, &[]);
+
+//Create the parser from the root command
+static PARSER: ArgParser = ArgParser::from(PARSER_ROOT_CMD);
+
+fn main() {
+    let root_cmd = PARSER.parse(); //Parse the command line arguments
+    match root_cmd {
+        Ok(result) => println!("Result: {:?}", result), //Print result
+        Err(error) => println!("ERROR: {:?}", error) //Print errors if occur
+    }
+}
  ```
 
 ### Links:
 [Github Repo](https://github.com/oxydemeton/arg_parse/) <br>
 [Crates.io](https://crates.io/crates/arg_parse)<br>
 [Rust Docs](https://docs.rs/arg_parse/latest/arg_parse/)
+ 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ arg_parse is a tool to simplify the processing of command line arguments. It doe
 - [x] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
 
 # Installation
-#### Only version 0.1.1 is published yet!
-Add `arg_parse = "0.1.1"` to your cargo dependencies (`cargo.toml`).
+Add `arg_parse = "0.2.1"` to your cargo dependencies (`cargo.toml`).
 ```toml
 [dependencies]
-arg_parse = "0.1.1"
+arg_parse = "0.2.1"
 ```
 
  # Example

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,45 +1,46 @@
 //! The config module includes everything to configure the [parser](parser::ArgParser)<br>
 //! Includes:
-//! - [enum Arg](config::Arg) to defer between Flags, Parameters
-//! - [struct Cmd](config::Cmd) to describe sub commands
+//! - [ShortOptions](config::ShortOption)
+//! - [LongOptions](config::LongOption)
+//! - [Commands](config::Cmd) a sub or the "root" command with its arguments and optionally a subcommand
 use std::vec;
 
-/// Enum for configuring arguments
+
 #[derive(Debug, Clone)]
-pub enum Arg {
-    /// Flags which are false by default and are set to true by being used by the user. <br>
-    /// Has its name as argument
-    Flag{ name: &'static str },
-    /// Parameters which are string inputs
-    /// Has its name as argument
-    Parameter{ name: &'static str}
+pub struct ShortOption{
+    pub name: char,
+    pub value_count: usize
+}
+#[derive(Debug, Clone)]
+pub struct LongOption{
+    pub name: &'static str,
+    pub value_count: usize
 }
 
 /// Describes the root and all sub commands. <br>
-/// A commands might have arguments ([enum Arg](Arg)) and possible sub commands which are also of type [Cmd](Cmd)
+/// A commands might have [short](ShortOption) and [long](LongOption) options and possible sub commands which are also of type [Cmd](Cmd)
 #[derive(Debug)]
 pub struct Cmd {
-    pub args: &'static[Arg],
+    pub short_options: &'static [ShortOption],
+    pub long_options: &'static [LongOption],
     pub sub_cmd: &'static[Cmd]
 }
 
 impl Cmd {
     /// Creates an Command without any possible arguments or sub commands
     pub const fn new()->Self {
-        Self { args: &[], sub_cmd: &[]}
+        Self { long_options: &[], short_options: &[], sub_cmd: &[]}
     }
     /// Creates a Commands having a list of arguments and sub commands
-    pub const fn from(args: &'static[Arg], sub_cmd: &'static[Cmd])->Self {
-        Self { args, sub_cmd}
+    pub const fn from(short_options: &'static [ShortOption], long_options: &'static [LongOption], sub_cmd: &'static[Cmd])->Self {
+        Self { short_options, long_options,  sub_cmd}
     }
     /// Function to parse only this subcommand with the arguments <br>
     /// Meant for use by the [parser](super::parser::ArgParser) internally
     pub fn parse(&self, arguments: &[String])->Result<super::result::Cmd, super::parser::ParseError> {
         use super::parser::ParseError;
-        let mut result = super::result::Cmd {
-            args: vec![],
-            sub_cmd: None,
-        };
+        use super::result;
+        let mut result = super::result::Cmd::new();
 
         let mut skip = 0;        
         for (i, a) in arguments.iter().enumerate() {
@@ -47,31 +48,49 @@ impl Cmd {
                 skip -= 1;
                 continue;
             }
-            if a.starts_with("--") { //Flags
-                let name = a.trim_start_matches("--");
-                match self.find_arg(name) {
-                    Some(a) => match a {
-                        Arg::Flag { name: self_name } => result.args.push(super::result::Arg::Flag{name: self_name, value: true}),
-                        Arg::Parameter { name: _ } => return Err(ParseError::TypeNameMismatch { name: String::from(name) }),
-                    },
-                    None => return Err(ParseError::UnknownFlag { name: String::from(name)}),
-                }
-                
-            }else if a.starts_with("-") { // Arguments
-                let name = a.trim_start_matches("-");
-                match self.find_arg(name) {
-                    Some(a) => match a {
-                        Arg::Parameter{name :self_name} => {
-                            if i+1 >= arguments.len() {
-                                return Err(ParseError::ParameterWithoutValue { name: String::from(name) });
+
+            //LongOption Parsing
+            if a.starts_with("--") { 
+                let option_option = self.find_long_option(a);
+                match option_option {
+                    Err(name) => return Err(ParseError::UnknownLongOption { name: String::from(name)}),
+                    Ok(option) => {
+                        if option.value_count == 0 {
+                            result.long_options.push(result::LongOption{name: option.name, values: vec![String::new()]})
+                        }else {
+                            let mut option_result = result::LongOption{name: option.name, values: vec![]};
+                            if option.value_count >= arguments.len() {
+                                return Err(ParseError::ParameterWithoutEnoughValues { name: String::from(option.name) })
                             }
-                            let value = arguments[i+1].clone();
-                            skip +=1;
-                            result.args.push(super::result::Arg::Parameter{ name: self_name, value: Some(value)})
-                        },
-                        Arg::Flag{name: _} => return Err(ParseError::TypeNameMismatch { name: String::from(name) }),
-                    },
-                    None => return Err(ParseError::UnknownParameter { name: String::from(name) }),
+                            skip = option.value_count;
+                            for i_value in i+1..i+option.value_count+1 {
+                                option_result.values.push(arguments[i_value].clone());
+                            }
+                            result.long_options.push(option_result);
+                        }
+                    }
+                }
+
+            }else if a.starts_with("-") { // Short Options
+                let options_option = self.find_short_options(a);
+                match options_option {
+                    Err(name) => return Err(ParseError::UnknownShortOption { name: String::from(name) }),
+                    Ok(options) => {
+                        for (i_option, option) in options.iter().enumerate() {
+                            let mut option_result = result::ShortOption{name: option.name, values: vec![]};
+                            if i_option == options.len()-1 && option.value_count > 0 {
+                                skip = option.value_count;
+                                for i_value in i+1..i+option.value_count+1 {
+                                    option_result.values.push(arguments[i_value].clone());
+                                }
+                            }else if option.value_count > 0 {
+                                return Err(ParseError::ShortOptionMissingValue { name: String::from(option.name) })
+                            }else {
+                                option_result.values.push(String::new());
+                            }
+                            result.short_options.push(option_result);
+                        }
+                    }
                 }
             } else { //Subcommand
                 todo!("Subcommands not implemented")
@@ -81,21 +100,29 @@ impl Cmd {
         Ok(result)        
     }
     //Find an argument by its name in the list of them
-    fn find_arg(&self, name: &str)-> Option<&Arg> {
-        for self_a in self.args {
-            match self_a {
-                Arg::Flag{name: self_name} => {
-                    if *self_name == name {
-                        return Some(self_a);
-                    }
-                },
-                Arg::Parameter{ name: self_name} => {
-                    if *self_name == name {
-                        return Some(self_a);
-                    }
-                },
+    fn find_short_options(&self, input_names: &str)-> Result<Vec<&ShortOption>, char> {
+        let names = input_names.trim_start_matches("-");
+        let mut result = vec![];
+        for c in names.chars() {
+            let len_before = result.len();
+            for o in self.short_options {
+                if o.name == c {
+                    result.push(o)
+                }
+            }
+            if result.len() == len_before {
+                return Err(c)
             }
         }
-        None
+        Ok(result)
+    }
+    fn find_long_option<'a>(&self, name_input: &'a str)-> Result<&LongOption, &'a str> {
+        let name = name_input.trim_start_matches("--");
+        for o in self.long_options {
+            if o.name == name {
+                return Ok(o)
+            }
+        }
+        Err(name)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@
 //! arg_parse is a tool to simplify the processing of command line arguments. It doesn't have any dependencies and the initialization is done at compile time.<br>
 //! 
 //! # Features & Goals
-//! - [x] Parsing of `flags` (Values set with `--` which default is false and set to true by being used.)
-//! - [x] Parsing of `parameters` (Values mentioned after `-` which have their value(as a string) followed)
+//! - [x] Parsing of `short options` (Values set with `--` which default is false and set to true by being used.)
+//! - [x] Parsing of `long options` (Values mentioned after `-` which have their value(as a string) followed)
+//! - [ ] Parsing of `non options` (Single Values parameters without any prefix )
 //! - [ ] Parsing of `sub commands` (which only one can be used and all following arguments are related to)
 //! - [x] Returning results instead of throwing unfinished error messages
 //! - [ ] Simple creation of parser
@@ -15,8 +16,7 @@
 //! - [ ] Ability to provide default values
 //! - [ ] Ability to make Argument or subcommand required
 //! - [ ] Cache the result of parsing the cli arguments to improve performance slightly
-//! - [ ] Easy macro or function to configure the parser
-//! - [ ] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
+//! - [x] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
 //! 
 //! # Installation
 //! #### Only version 0.1.1 is published yet!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 //! # Disclaimer
 //! The interface for developer is work in progress. So expect minor and major changes when updating until v1.0<br>
 //! # Description
-//! arg_parse is a tool to simplify the processing of command line arguments. It doesn't have any dependencies and the initialization is done at compile time.
-//!  
+//! arg_parse is a tool to simplify the processing of command line arguments. It doesn't have any dependencies and the initialization is done at compile time.<br>
+//! 
 //! # Features & Goals
 //! - [x] Parsing of `flags` (Values set with `--` which default is false and set to true by being used.)
 //! - [x] Parsing of `parameters` (Values mentioned after `-` which have their value(as a string) followed)
@@ -16,37 +16,56 @@
 //! - [ ] Ability to make Argument or subcommand required
 //! - [ ] Cache the result of parsing the cli arguments to improve performance slightly
 //! - [ ] Easy macro or function to configure the parser
-//! - [ ] fulfill common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
+//! - [ ] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
 //! 
 //! # Installation
+//! #### Only version 0.1.1 is published yet!
 //! Add `arg_parse = "0.1.1"` to your cargo dependencies (`cargo.toml`).
 //! ```toml
 //! [dependencies]
 //! arg_parse = "0.1.1"
 //! ```
-//! # Example
-//! Prints if the flag `--a` is provided and the parameter provided under `-b`
-//! ```rust
+//! 
+//!  # Example
+//!  Prints the Options which are found or parsing errors.<br>
+//!  Arguments:
+//!  - LongOption: `hello` without any further arguments
+//!  - ShortOption: `b` with two arguments
+//!  - ShortOption: `a` without any arguments
+//!  ```rust
 //! use arg_parse::ArgParser;
 //! use arg_parse::config;
-//! // Define all Arguments of the program itself/root command (compile time)
-//! const ARGS: &'static [config::Arg] = &[config::Arg::Flag{ name: "a" }, config::Arg::Parameter{ name: "b" }];
-//! // Define the Root Command, without any possible sub commands (compile time)
-//! const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(ARGS, &[]);
-//! // Create the Parser in static memory, available everywhere (Created at compile time)
+//! 
+//! //List of all available long options
+//! const LONG_OPTIONS: &'static [config::LongOption] = &[
+//!     //Define a long option called hello without parameters
+//!     config::LongOption{name: "hello", value_count: 0}
+//!     ];
+//! //List of all available short options
+//! const SHORT_OPTIONS: &'static [config::ShortOption] = &[
+//!     //Define a short option called b with two parameters
+//!     config::ShortOption{name:'b', value_count: 2},
+//!     //Define a short option called a without parameters
+//!     config::ShortOption{name:'a', value_count: 0}
+//!     ];
+//! 
+//! //Create the root command which is the program itself basically
+//! const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(SHORT_OPTIONS, LONG_OPTIONS, &[]);
+//! 
+//! //Create the parser from the root command
 //! static PARSER: ArgParser = ArgParser::from(PARSER_ROOT_CMD);
 //! 
 //! fn main() {
-//!     //Parse the by the user provided Arguments
-//!     let root_cmd = PARSER.parse();
+//!     let root_cmd = PARSER.parse(); //Parse the command line arguments
 //!     match root_cmd {
-//!         Ok(result) => println!("Result: {:?}", result),
-//!         Err(error) => println!("ERROR: {:?}", error)
+//!         Ok(result) => println!("Result: {:?}", result), //Print result
+//!         Err(error) => println!("ERROR: {:?}", error) //Print errors if occur
 //!     }
 //! }
-//! ```
+//!  ```
+//! 
 //! ### Links:
-//! [Github Repo](https://github.com/oxydemeton/arg_parse/)<br>
+//! [Github Repo](https://github.com/oxydemeton/arg_parse/) <br>
 //! [Crates.io](https://crates.io/crates/arg_parse)<br>
 //! [Rust Docs](https://docs.rs/arg_parse/latest/arg_parse/)
  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,10 @@
 //! - [x] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)
 //! 
 //! # Installation
-//! #### Only version 0.1.1 is published yet!
-//! Add `arg_parse = "0.1.1"` to your cargo dependencies (`cargo.toml`).
+//! Add `arg_parse = "0.2.0"` to your cargo dependencies (`cargo.toml`).
 //! ```toml
 //! [dependencies]
-//! arg_parse = "0.1.1"
+//! arg_parse = "0.2.0"
 //! ```
 //! 
 //!  # Example

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,20 @@
 use arg_parse::ArgParser;
 use arg_parse::config;
 
-
-const ARGS: &'static [config::Arg] = &[config::Arg::Flag { name: "a" }, config::Arg::Parameter { name: "b" }];
-const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(ARGS, &[]);
+const LONG_OPTIONS: &'static [config::LongOption] = &[
+    config::LongOption{name: "hello", value_count: 0}
+    ];
+const SHORT_OPTIONS: &'static [config::ShortOption] = &[
+    config::ShortOption{name:'b', value_count: 2},
+    config::ShortOption{name:'a', value_count: 0}
+    ];
+const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(SHORT_OPTIONS, LONG_OPTIONS, &[]);
 
 static PARSER: ArgParser = ArgParser::from(PARSER_ROOT_CMD);
 
 fn main() {
     let root_cmd = PARSER.parse();
+    assert!(matches!(root_cmd, Ok(_)));
     match root_cmd {
         Ok(result) => println!("Result: {:?}", result),
         Err(error) => println!("ERROR: {:?}", error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ static PARSER: ArgParser = ArgParser::from(PARSER_ROOT_CMD);
 
 fn main() {
     let root_cmd = PARSER.parse();
-    assert!(matches!(root_cmd, Ok(_)));
     match root_cmd {
         Ok(result) => println!("Result: {:?}", result),
         Err(error) => println!("ERROR: {:?}", error)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,8 +70,6 @@ pub enum ParseError {
     UnknownShortOption{ name: String },
     /// The user provided a `long option` which isn't defined
     UnknownLongOption{ name: String },
-    /// The user provided a `long option` which is defined as a `short option` or vice versa. *(Planed to be removed)*
-    TypeNameMismatch{ name: String },
     /// The user provided a parameter but did not gave a value
     ParameterWithoutEnoughValues{ name: String },
     /// A Short Option which expects values was used inside a combination of multiple once

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,9 +10,14 @@ impl ArgParser {
     /// Create a new Parser, giving the "root" command
     /// # Example
     /// ```rust
-    /// const ARGS: &'static [config::Arg] = &[config::Arg::Flag("a"), config::Arg::Parameter("b")];
-    /// const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(ARGS, &[]);
-    /// static PARSER: ArgParser = ArgParser::from(PARSER_ROOT_CMD);
+    /// const LONG_OPTIONS: &'static [config::LongOption] = &[
+    /// config::LongOption{name: "hello", value_count: 0}
+    ///     ];
+    /// const SHORT_OPTIONS: &'static [config::ShortOption] = &[
+    ///     config::ShortOption{name:'b', value_count: 2},
+    ///     config::ShortOption{name:'a', value_count: 0}
+    ///     ];
+    /// const PARSER_ROOT_CMD: config::Cmd = config::Cmd::from(SHORT_OPTIONS, LONG_OPTIONS, &[]);
     /// ```
     pub const fn from(c: config::Cmd)-> Self {
         Self {
@@ -27,12 +32,7 @@ impl ArgParser {
     }
     /// Function parsing the command line arguments from [std::env::args()](std::env::args()) with the configuration
     /// # Errors
-    /// Described with [ParseError](ParseError)
-    /// - [NoArguments](ParseError::NoArguments) --> No arguments were provided. Doesn't have to be wrong but leads to no result.
-    /// - [UnknownFlag](ParseError::UnknownFlag) --> The user provided a `flag` which isn't defined
-    /// - [UnknownParameter](ParseError::UnknownParameter) --> The user provided a `parameter` which isn't defined
-    /// - [TypeNameMismatch](ParseError::TypeNameMismatch) --> The user provided a flag which is defined as a parameter or vice versa. *(Planed to be removed)*
-    /// - [ParameterWithoutValue](ParseError::ParameterWithoutValue) --> The user provided a parameter but did not gave a value
+    /// Described in [ParseError](ParseError)
 
     pub fn parse(&self) -> Result<result::Cmd, ParseError> {
         let mut sys_args: Vec<String> = std::env::args().collect();
@@ -66,12 +66,14 @@ impl ArgParser {
 pub enum ParseError {
     /// No arguments were provided. Doesn't have to be wrong but leads to no result.
     NoArguments,
-    /// The user provided a `flag` which isn't defined
-    UnknownFlag{ name: String },
-    /// The user provided a `parameter` which isn't defined
-    UnknownParameter{ name: String },
-    /// The user provided a flag which is defined as a parameter or vice versa. *(Planed to be removed)*
+    /// The user provided a `short option` which isn't defined
+    UnknownShortOption{ name: String },
+    /// The user provided a `long option` which isn't defined
+    UnknownLongOption{ name: String },
+    /// The user provided a `long option` which is defined as a `short option` or vice versa. *(Planed to be removed)*
     TypeNameMismatch{ name: String },
     /// The user provided a parameter but did not gave a value
-    ParameterWithoutValue{ name: String }
+    ParameterWithoutEnoughValues{ name: String },
+    /// A Short Option which expects values was used inside a combination of multiple once
+    ShortOptionMissingValue{ name: String },
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,22 +1,41 @@
 //! Includes all results of the [parser](parser::ArgParser)<br>
 //! Includes:
-//! - [enum Arg](result::Arg) includes every kind of Argument and its value
-//! - [struct Cmd](result::Cmd) a sub or the "root" command with its arguments and optionally a subcommand
+//! - [ShortOptions](result::ShortOption)
+//! - [LongOptions](result::LongOption)
+//! - [Commands](result::Cmd) a sub or the "root" command with its arguments and optionally a subcommand
 
-/// includes every kind of Argument and its value
+/// Description of a used short option <br>
+/// ## Usage in command line:
+/// - `-n` for a short option called `n` without any parameter
+/// - `-n value` for a option called `n` with one value
+/// - `-ab` for a short option called `a` and one called `b`
+/// - `-ab value-one value-two` for a short option called `a` without parameters and one called `b` with two
 #[derive(Debug, Clone)]
-pub enum Arg {
-    /// A Flag selected by the user which contains its name and if it was selected
-    Flag{name: &'static str, value: bool},
-    /// A Parameter selected by the user and it's value as a String
-    Parameter{ name: &'static str, value: Option<String>}
+pub struct ShortOption{
+    pub name: char,
+    pub values: Vec<String>
+}
+
+/// Description of a used long option <br>
+/// ## Usage in command line
+/// - `--name` for a long argument called `name`
+/// - `--name value` for a long argument called `name` with one parameter
+#[derive(Debug, Clone)]
+pub struct LongOption{
+    pub name: &'static str,
+    pub values: Vec<String>
 }
 
 /// Command selected by the user
 #[derive(Debug)]
 pub struct Cmd {
-    /// All given Arguments to this specific command
-    pub args: Vec<Arg>,
-    /// If provided the given subcommand
+    pub short_options: Vec<ShortOption>,
+    pub long_options: Vec<LongOption>,
     pub sub_cmd: Option<Box<Cmd>>
+}
+
+impl Cmd {
+    pub fn new()->Self {
+        Self { short_options: vec![], long_options: vec![], sub_cmd: None }
+    }
 }


### PR DESCRIPTION
# Changes
- Replaced flags and parameters with 

# Goals and Features (Updated)
- [x] Parsing of `short options` (Values set with `--` which default is false and set to true by being used.)
- [x] Parsing of `long options` (Values mentioned after `-` which have their value(as a string) followed)
- [ ] Parsing of `non options` (Single Values parameters without any prefix )
- [ ] Parsing of `sub commands` (which only one can be used and all following arguments are related to)
- [x] Returning results instead of throwing unfinished error messages
- [ ] Simple creation of parser
- [x] Ability to create parser as constant or static variable (at compile time)
- [x] Ability to give a list of arguments (not using args from [std::env::args()](std::env::args()))
- [ ] Ability to provide default values
- [ ] Ability to make Argument or subcommand required
- [ ] Cache the result of parsing the cli arguments to improve performance slightly
- [x] fulfill  common patters, like described in this [specification](https://gist.github.com/pksunkara/1485856)